### PR TITLE
changes from LF to CRLF mac to windows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: v5.0.0
     hooks:
       - id: check-added-large-files
+        args: [--maxkb=15000]
       - id: check-ast
       - id: check-merge-conflict
       - id: check-toml


### PR DESCRIPTION
This PR mainly adds a pdf of the course notes to the `docs/assets/` folder so that this can be read quickly from finder rather than needing to open and run mkdocs serve when working on other projects